### PR TITLE
fbpdf: fix format-security error

### DIFF
--- a/fbpdf.c
+++ b/fbpdf.c
@@ -347,7 +347,7 @@ int main(int argc, char *argv[])
 {
 	int i = 1;
 	if (argc < 2) {
-		printf(usage);
+		printf("%s", usage);
 		return 1;
 	}
 	strcpy(filename, argv[argc - 1]);


### PR DESCRIPTION
Using printf without a formatting string is a security vulnerability,
and most distributions now default to using `-Werror=format-security`.

See https://fedoraproject.org/wiki/Format-Security-FAQ