### PR TITLE
use float type for zoom

### DIFF
--- a/djvulibre.c
+++ b/djvulibre.c
@@ -42,7 +42,7 @@ static void djvu_render(ddjvu_page_t *page, int iw, int ih, void *bitmap)
 	ddjvu_format_release(fmt);
 }
 
-void *doc_draw(struct doc *doc, int p, int zoom, int rotate, int *rows, int *cols)
+void *doc_draw(struct doc *doc, int p, float zoom, int rotate, int *rows, int *cols)
 {
 	ddjvu_page_t *page;
 	ddjvu_pageinfo_t info;

--- a/doc.h
+++ b/doc.h
@@ -6,5 +6,5 @@ typedef unsigned int fbval_t;
 
 struct doc *doc_open(char *path);
 int doc_pages(struct doc *doc);
-void *doc_draw(struct doc *doc, int page, int zoom, int rotate, int *rows, int *cols);
+void *doc_draw(struct doc *doc, int page, float zoom, int rotate, int *rows, int *cols);
 void doc_close(struct doc *doc);

--- a/fbpdf.c
+++ b/fbpdf.c
@@ -47,7 +47,7 @@ static int mark[128];		/* mark page number */
 static int mark_row[128];	/* mark head position */
 static int num = 1;		/* page number */
 static int numdiff;		/* G command page number difference */
-static int zoom = 15;
+static float zoom = 15;
 static int zoom_def = 15;	/* default zoom */
 static int rotate;
 static int count;
@@ -89,9 +89,9 @@ static int loadpage(int p)
 	return 0;
 }
 
-static void zoom_page(int z)
+static void zoom_page(float z)
 {
-	int _zoom = zoom;
+	float _zoom = zoom;
 	zoom = MIN(MAXZOOM, MAX(1, z));
 	if (!loadpage(num))
 		srow = srow * zoom / _zoom;
@@ -136,7 +136,7 @@ static int getcount(int def)
 static void printinfo(void)
 {
 	printf("\x1b[H");
-	printf("FBPDF:     file:%s  page:%d(%d)  zoom:%d%% \x1b[K\r",
+	printf("FBPDF:     file:%s  page:%d(%d)  zoom:%f%% \x1b[K\r",
 		filename, num, doc_pages(doc), zoom * 10);
 	fflush(stdout);
 }

--- a/mupdf.c
+++ b/mupdf.c
@@ -11,7 +11,7 @@ struct doc {
 	fz_document *pdf;
 };
 
-void *doc_draw(struct doc *doc, int p, int zoom, int rotate, int *rows, int *cols)
+void *doc_draw(struct doc *doc, int p, float zoom, int rotate, int *rows, int *cols)
 {
 	fz_matrix ctm;
 	fz_pixmap *pix;

--- a/poppler.c
+++ b/poppler.c
@@ -27,7 +27,7 @@ static poppler::rotation_enum rotation(int times)
 	return poppler::rotate_0;
 }
 
-void *doc_draw(struct doc *doc, int p, int zoom, int rotate, int *rows, int *cols)
+void *doc_draw(struct doc *doc, int p, float zoom, int rotate, int *rows, int *cols)
 {
 	poppler::page *page = doc->doc->create_page(p - 1);
 	poppler::page_renderer pr;


### PR DESCRIPTION
fbpdf was used for my presentation on the Linux Framebuffer at FOSDEM 2020 (https://fosdem.org/2020/schedule/event/fbdev).
I replaced the "int" type by "float" for the zoom variable in order to fill the entire screen when using 'f' or 'w' command.
Thanks for this great tool !